### PR TITLE
added packet size and v6 support to test_dts

### DIFF
--- a/explorer/config/grafana-dashboards/benchmark.json
+++ b/explorer/config/grafana-dashboards/benchmark.json
@@ -375,7 +375,7 @@
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
-          "refId": "dts"
+          "refId": "dts_8972"
         }
       ],
       "title": "[$id_a] Variance coefficient of bandwidth by test",
@@ -457,7 +457,7 @@
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
-          "refId": "dts"
+          "refId": "dts_8972"
         }
       ],
       "title": "[$id_b] Variance coefficient of bandwidth by test",
@@ -6537,8 +6537,28 @@
           },
           {
             "selected": false,
-            "text": "dts",
-            "value": "dts"
+            "text": "dts_88",
+            "value": "dts_88"
+          },
+          {
+            "selected": false,
+            "text": "dts_1472",
+            "value": "dts_1472"
+          },
+          {
+            "selected": false,
+            "text": "dts_8972",
+            "value": "dts_8972"
+          },
+          {
+            "selected": false,
+            "text": "dts_1472_v6",
+            "value": "dts_1472_v6"
+          },
+          {
+            "selected": false,
+            "text": "dts_8972_v6",
+            "value": "dts_8972_v6"
           },
           {
             "selected": false,
@@ -6556,7 +6576,7 @@
             "value": "stm"
           }
         ],
-        "query": "dts,dtm,sts,stm",
+        "query": "dts_88,dts_1472,dts_8972,dts_1472_v6,dts_8972_v6,tm,sts,stm",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"


### PR DESCRIPTION
  * vars added to capture the ipv6 addresses for podA2 and svc A2
  * test_dts has been updated to accept MSS size and v6 remote target addresses
  * test_dts is now run with 3 TCP MSS sizes to influence packet sizes: 88 bytes, 1472 bytes, and 8972 bytes
  * test_dts is also now run with 2 ipv6 passes, one for 1472 byte MSS and the other for 8972 byte MSS. ipv6 doesn't support an MSS of 88
  * the grafana benchmark dashboard json has been updated to graph the updated test_dts data